### PR TITLE
Fix : 사업계획서 생성시 success 페이지에 제대로 출력이 안되던 오류 및 질문과 답안 순서가 어긋나는 오류 해결

### DIFF
--- a/src/pages/Upload/hook.tsx
+++ b/src/pages/Upload/hook.tsx
@@ -115,17 +115,23 @@ export const useUpload = () => {
   const mutPostAnswerProposal = useMutation({
       mutationFn: async (input: ProposalInputType) => {
         const { proposalSummary, answerType } = input;
-        await Promise.all(
+        const result = await Promise.all(
           Object.entries(proposalSummary).map(async ([key, props]) => {
-            const value = await proposalApi.postAnswerProposal({
-              accessToken,
-              referenceFileIds: propsGenerateProposalSummary.current.referenceFileIds,
-              answerType,
-              ...props,
-            });
-            setResProposal((prev) => [...prev, value]);
+            try {
+              return await proposalApi.postAnswerProposal({
+                accessToken,
+                referenceFileIds: propsGenerateProposalSummary.current.referenceFileIds,
+                answerType,
+                ...props,
+              });
+            } catch (e) {
+              console.log(e)
+              return '다시한번 시도해주세요'
+            }
           })
         );
+        setResProposal(result);
+
       },
       onSuccess: () => navigate("/success"),
     }
@@ -196,7 +202,7 @@ export const useUpload = () => {
     </successAlert.Alert>
   );
   const SelectBoxModal = () => {
-    const [answerType, setAnswerType] = React.useState<string>("");
+    const [answerType, setAnswerType] = React.useState<string>("descriptive");
     const [selected, setSelected] = React.useState<boolean[]>(
       Object.entries(proposalSummary).map((x) => true)
     );
@@ -255,6 +261,7 @@ export const useUpload = () => {
               const selectedSummary = Object.entries(proposalSummary).filter(
                 (_, idx) => selected[idx]
               );
+              setSelectedSummary(selectedSummary.map((x) => x[1].question!));
               mutPostAnswerProposal.mutate({
                 answerType,
                 proposalSummary: Object.fromEntries(selectedSummary)


### PR DESCRIPTION
- AtomValue를 사용하는 부분해 hook에서 success에 들어갈 값을 변경할 수 있게 함.
- promiseAll은 리스트의 순서를 보장하지 않고 동작하는데, 이 값을 순서대로 setResProposal()을 사용하여 순서가 어긋나는 문제 -> promise.all의 결과값을 리스트 순서를 지켜 그대로 전달하여 해결함.
- promise.all을 할때 하나의 값이라도 에러가 나면 전체 결과가 출력이 안됐는데, try문으로 에러를 감싸 '다시한번 시도해주세요' 라는 메세지가 출력되도록 수정.

- 추가로, answerType의 Default가 간혹 적용 안될때가 있어 useState의 초깃값 설정